### PR TITLE
Properly count subregion reference destruction towards root region unmapping

### DIFF
--- a/legate/core/store.py
+++ b/legate/core/store.py
@@ -197,9 +197,9 @@ class RegionField(object):
             return self.parent.get_inline_mapped_region(context)
 
     def decrement_inline_mapped_ref_count(self, unordered=False):
-        if self.physical_region is None:
-            return
         if self.parent is None:
+            if self.physical_region is None:
+                return
             assert self.physical_region_refs > 0
             self.physical_region_refs -= 1
             if self.physical_region_refs == 0:
@@ -209,7 +209,7 @@ class RegionField(object):
                 self.physical_region = None
                 self.physical_region_mapped = False
         else:
-            self.parent.decrement_inline_mapped_ref_count()
+            self.parent.decrement_inline_mapped_ref_count(unordered=unordered)
 
     def get_inline_allocation(self, shape, context=None, transform=None):
         context = self.runtime.context if context is None else context


### PR DESCRIPTION
Without this change we could miss the unmapping of an inline-mapped RegionField, even after we recycle it for a different Store. This would cause a conflict if we then try to inline map the second Store, e.g. in the following example:

```
for _ in range(8):
    arr = lg.ones((5,5,5))[1:2,1:2,1:2]
    arr._thunk.__numpy_array__()
```

which would produce the following logging output:

```
attaching Region(tid: 1, is: 13, fs: 1, fid: 1048577) :: going to parent
attaching Region(tid: 1, is: 1, fs: 1, fid: 1048577) :: got to root, attaching
reducing inline ref count for RegionField(tid: 1, is: 13, fs: 1, fid: 1048577), count = 0
parent: RegionField(tid: 1, is: 1, fs: 1, fid: 1048577), count = 1
self.physical_region is None => fast exit
attaching Region(tid: 1, is: 13, fs: 1, fid: 1048578) :: going to parent
attaching Region(tid: 1, is: 1, fs: 1, fid: 1048578) :: got to root, attaching
reducing inline ref count for RegionField(tid: 1, is: 13, fs: 1, fid: 1048578), count = 0
parent: RegionField(tid: 1, is: 1, fs: 1, fid: 1048578), count = 1
self.physical_region is None => fast exit
attaching Region(tid: 1, is: 13, fs: 1, fid: 1048579) :: going to parent
attaching Region(tid: 1, is: 1, fs: 1, fid: 1048579) :: got to root, attaching
reducing inline ref count for RegionField(tid: 1, is: 13, fs: 1, fid: 1048579), count = 0
parent: RegionField(tid: 1, is: 1, fs: 1, fid: 1048579), count = 1
self.physical_region is None => fast exit
attaching Region(tid: 1, is: 13, fs: 1, fid: 1048580) :: going to parent
attaching Region(tid: 1, is: 1, fs: 1, fid: 1048580) :: got to root, attaching
reducing inline ref count for RegionField(tid: 1, is: 13, fs: 1, fid: 1048580), count = 0
parent: RegionField(tid: 1, is: 1, fs: 1, fid: 1048580), count = 1
self.physical_region is None => fast exit
attaching Region(tid: 1, is: 13, fs: 1, fid: 1048581) :: going to parent
attaching Region(tid: 1, is: 1, fs: 1, fid: 1048581) :: got to root, attaching
reducing inline ref count for RegionField(tid: 1, is: 13, fs: 1, fid: 1048581), count = 0
parent: RegionField(tid: 1, is: 1, fs: 1, fid: 1048581), count = 1
self.physical_region is None => fast exit
attaching Region(tid: 1, is: 13, fs: 1, fid: 1048582) :: going to parent
attaching Region(tid: 1, is: 1, fs: 1, fid: 1048582) :: got to root, attaching
reducing inline ref count for RegionField(tid: 1, is: 13, fs: 1, fid: 1048582), count = 0
parent: RegionField(tid: 1, is: 1, fs: 1, fid: 1048582), count = 1
self.physical_region is None => fast exit
attaching Region(tid: 1, is: 13, fs: 1, fid: 1048583) :: going to parent
attaching Region(tid: 1, is: 1, fs: 1, fid: 1048583) :: got to root, attaching
reducing inline ref count for RegionField(tid: 1, is: 13, fs: 1, fid: 1048583), count = 0
parent: RegionField(tid: 1, is: 1, fs: 1, fid: 1048583), count = 1
self.physical_region is None => fast exit
attaching Region(tid: 1, is: 13, fs: 1, fid: 1048577) :: going to parent
attaching Region(tid: 1, is: 1, fs: 1, fid: 1048577) :: got to root, attaching
[0 - 7f5bac551700]    2.738872 {5}{runtime}: [error 395] LEGION ERROR: Attempted an inline mapping of region (1,1,1) that conflicts with previous inline mapping in task legion_python_main (ID 1) that would ultimately result in deadlock.  Instead you
receive this error message. (from file /gpfs/fs1/mpapadakis/legate.core/legion/runtime/legion/legion_context.cc:6568)
```