### PR TITLE
Export time from legate.timing

### DIFF
--- a/src/python/legate/timing/__init__.py
+++ b/src/python/legate/timing/__init__.py
@@ -5,4 +5,4 @@ from __future__ import annotations
 
 from ._lib.timing import time
 
-__all__ = ['time']
+__all__ = ["time"]

--- a/src/python/legate/timing/__init__.py
+++ b/src/python/legate/timing/__init__.py
@@ -4,3 +4,5 @@
 from __future__ import annotations
 
 from ._lib.timing import time
+
+__all__ = ['time']


### PR DESCRIPTION
This is a band-aid around #975 until we get a real fix. For now this addresses the main sore point in my code that I cannot use `legate.timing.time` without type checkers complaining that the function has not been exported.