### PR TITLE
Expose `Library::get_library_name` from Python

### DIFF
--- a/src/python/legate/core/_lib/runtime/library.pxd
+++ b/src/python/legate/core/_lib/runtime/library.pxd
@@ -4,6 +4,7 @@
 
 from libc.stdint cimport int64_t
 
+from ..._ext.cython_libcpp.string_view cimport std_string_view
 from ..data.scalar cimport Scalar, _Scalar
 from ..task.task_info cimport TaskInfo, _TaskInfo
 from ..type.types cimport Type, _Type
@@ -20,6 +21,7 @@ cdef extern from "legate/runtime/library.h" namespace "legate" nogil:
     cdef cppclass _Library "legate::Library":
         _Library() except+
         _Library(const _Library&) except+
+        std_string_view get_library_name() except+
         _LocalTaskID get_new_task_id() except+
         _GlobalTaskID get_task_id(_LocalTaskID) except+
         _GlobalRedopID get_reduction_op_id(_LocalRedopID) except+
@@ -33,6 +35,7 @@ cdef class Library(Unconstructable):
     @staticmethod
     cdef Library from_handle(_Library)
 
+    cpdef str get_library_name(self)
     cpdef _LocalTaskID get_new_task_id(self)
     cpdef _GlobalTaskID get_task_id(self, _LocalTaskID local_task_id)
     cpdef _GlobalRedopID get_reduction_op_id(

--- a/src/python/legate/core/_lib/runtime/library.pyi
+++ b/src/python/legate/core/_lib/runtime/library.pyi
@@ -14,6 +14,7 @@ from ..utilities.typedefs import (
 from ..utilities.unconstructable import Unconstructable
 
 class Library(Unconstructable):
+    def get_library_name(self) -> str: ...
     def get_new_task_id(self) -> LocalTaskID: ...
     # This prototype is a lie, technically (in Cython) it's only LocalTaskID,
     # but we allow int as a type-checking convenience to users

--- a/src/python/legate/core/_lib/runtime/library.pyx
+++ b/src/python/legate/core/_lib/runtime/library.pyx
@@ -4,6 +4,7 @@
 
 from libc.stdint cimport int64_t, uintptr_t
 
+from ..._ext.cython_libcpp.string_view cimport str_from_string_view
 from ..data.scalar cimport Scalar
 from ..type.types cimport Type
 from ..utilities.typedefs cimport _GlobalTaskID, _LocalTaskID
@@ -16,6 +17,17 @@ cdef class Library(Unconstructable):
         cdef Library result = Library.__new__(Library)
         result._handle = handle
         return result
+
+    cpdef str get_library_name(self):
+        r"""
+        Returns the name of the library.
+
+        Returns
+        -------
+        str
+            The library name.
+        """
+        return str_from_string_view(self._handle.get_library_name())
 
     cpdef _LocalTaskID get_new_task_id(self):
         r"""


### PR DESCRIPTION
Fixes #986.

Warning: currently untested, but locally passes commit hooks.