### PR TITLE
[DRAFT] CMake fixes necessary when importing existing legion

### DIFF
--- a/src/cmake/thirdparty/get_legion.cmake
+++ b/src/cmake/thirdparty/get_legion.cmake
@@ -84,7 +84,7 @@ function(find_or_configure_legion_impl version git_repo git_branch shallow
   rapids_cpm_find(Legion "${version}"
                   BUILD_EXPORT_SET legate-exports
                   INSTALL_EXPORT_SET legate-exports
-                  GLOBAL_TARGETS Legion::Regent Legion::Legion Legion::LegionRuntime
+                  GLOBAL_TARGETS Legion::Legion Legion::LegionRuntime
                   CPM_ARGS ${legion_cpm_git_args}
                            # HACK: Legion headers contain *many* warnings, but we would
                            # like to build with -Wall -Werror. But there is a work-around.

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -708,7 +708,13 @@ foreach(target legate_obj legate)
 endforeach()
 
 # See https://github.com/nv-legate/legate.internal/pull/1326#issuecomment-2418791698
-foreach(target legate_obj legate LegionRuntime)
+set(LEGATE_TARGETS_TO_MODIFY legate_obj legate)
+# check if LegionRuntime is built or imported and add it to list if built here
+if(TARGET LegionRuntime)
+    list(APPEND LEGATE_TARGETS_TO_MODIFY LegionRuntime)
+endif()
+
+foreach(target ${LEGATE_TARGETS_TO_MODIFY})
   target_compile_definitions("${target}" PUBLIC LIBCUDACXX_ENABLE_HOST_NVFP16=1)
   if(legate_USE_CUDA)
     # CCCL 2.7.0 (which is what we use) disables __half support if it detects that it


### PR DESCRIPTION
* If Legion is an imported target (i.e the un-aliased target doesn't exist) don't apply flags to it
* `Legion::Regent` is not required to have been built by the external Legion